### PR TITLE
Fix only show 1 notification per event

### DIFF
--- a/Maggol/Application/Features/Notification/SetReleaseNotification.swift
+++ b/Maggol/Application/Features/Notification/SetReleaseNotification.swift
@@ -47,6 +47,8 @@ private extension SetReleaseNotification {
     }
     
     func scheduleNotification(for model: NotificationModel) async {
+        if notificationIsTracked(model) { return }
+        
         let content = UNMutableNotificationContent()
         content.title = "Nieuw: \(model.name)"
         content.body = "Aangekondigd voor release op \(model.release)"
@@ -71,5 +73,17 @@ private extension SetReleaseNotification {
         } catch {
             print("Failed to schedule notification: \(error)")
         }
+        
+        trackScheduledNotification(model)
+    }
+    
+    func notificationIsTracked(_ model: NotificationModel) -> Bool {
+        let defaults = UserDefaults.standard
+        return defaults.bool(forKey: model.name)
+    }
+    
+    func trackScheduledNotification(_ model: NotificationModel) {
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: model.name)
     }
 }


### PR DESCRIPTION
Als je de app meerdere keren opstart, dan worden de notificaties meerdere keren in de queue gezet. Nu niet meer